### PR TITLE
#16 Fix react-sortable-tree version

### DIFF
--- a/geppetto.js/package.json
+++ b/geppetto.js/package.json
@@ -76,7 +76,7 @@
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.0",
     "react-slick": "^0.23.2",
-    "react-sortable-tree": "^2.6.2",
+    "react-sortable-tree": "2.6.1",
     "react-tabtab": "^2.0.0",
     "remarkable": "^1.7.3",
     "slick-carousel": "^1.6.0",


### PR DESCRIPTION
closes #16 
The problem seems to be upstream: frontend-collective/react-sortable-tree#456 so I'm fixing the library on working versions for now.
Also, please have a look at https://github.com/openworm/geppetto-client/pull/354