### PR TITLE
Feature/24 showcase dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/node_modules/
+pygeppetto/
+jupyter-geppetto/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# node-sass 4.14.1 requires node version <= 14 for Alpine Linux
+# See: https://github.com/sass/node-sass/releases/tag/v4.14.1
+FROM node:14.16.1-alpine3.10 AS build-stage
+
+WORKDIR /app
+
+# YARN REQUIRES GIT BINARY
+RUN apk add git
+
+# COPY PACKAGE MANAGEMENT FILES + DEPENDENCIES
+COPY geppetto-showcase/package*.json geppetto-showcase/
+COPY geppetto-showcase/yarn.lock geppetto-showcase/
+COPY geppetto.js geppetto.js
+
+# INSTALL PACKAGES
+WORKDIR geppetto-showcase
+RUN yarn
+
+# COPY SOURCE CODE
+COPY geppetto-showcase .
+
+# BUILD
+RUN npm run build
+
+####################################################################
+
+FROM nginx:alpine
+COPY --from=build-stage /app/geppetto-showcase/dist/ /usr/share/nginx/html
+
+RUN rm /etc/nginx/conf.d/default.conf
+COPY geppetto-showcase/nginx/nginx.conf /etc/nginx/conf.d

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 # See: https://github.com/sass/node-sass/releases/tag/v4.14.1
 FROM node:14.16.1-alpine3.10 AS build-stage
 
+# NGINX PORT
+EXPOSE 80
+
 WORKDIR /app
 
 # YARN REQUIRES GIT BINARY

--- a/geppetto-showcase/README.md
+++ b/geppetto-showcase/README.md
@@ -2,14 +2,27 @@
   <img src="https://github.com/tarelli/bucket/blob/master/geppetto%20logo.png?raw=true" alt="Geppetto logo"/>
 </p>
 
-
 ## Geppetto Showcase
 
-Geppetto's showcase of components & features
+Geppetto Meta showcase of components & features
 
-## How to develop
+## Development
 
 1. `git clone -b development https://github.com/MetaCell/geppetto-meta.git`
 2. `cd geppetto-meta/geppetto-showcase`
 4. `yarn`
 5. `yarn start`
+
+## Deployment
+
+Build Dockerfile from root level of geppetto-meta repository:
+
+```bash
+docker build -t geppetto-showcase .
+```
+
+Start container with:
+
+````bash
+docker run -p 8080:80 geppetto-showcase 
+````

--- a/geppetto-showcase/nginx/nginx.conf
+++ b/geppetto-showcase/nginx/nginx.conf
@@ -1,0 +1,22 @@
+server {
+    listen 80;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        gzip on;
+        gzip_vary on;
+        gzip_min_length 10240;
+        gzip_proxied expired no-cache no-store private auth;
+        gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml;
+        gzip_disable "MSIE [1-6]\.";
+
+        try_files $uri $uri/ /index.html;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/geppetto-showcase/webpack.config.js
+++ b/geppetto-showcase/webpack.config.js
@@ -2,7 +2,7 @@ const HtmlWebPackPlugin = require('html-webpack-plugin');
 const path = require('path');
 
 module.exports = {
-  entry: path.resolve(__dirname, './src/index.js'),
+  entry: './src/index.js',
   mode: 'development',
   devtool: 'inline-source-map',
   devServer: {
@@ -10,9 +10,9 @@ module.exports = {
   },
   node: { fs: 'empty', },
   output: {
-    path: path.resolve(__dirname, '/'),
-    filename: "[name].bundle.js",
-    chunkFilename: "[name].chunk.js",
+    path: __dirname + 'dist',
+    filename: '[name].bundle.js',
+    chunkFilename: '[name].chunk.js',
     publicPath: '/'
   },
   resolve: {


### PR DESCRIPTION
Since geppeto.js is integrated by using relative file path, Dockerfile is placed at the root level so that geppetto.js becomes part of the Docker context. Once we change the geppetto.js integration, Dockerfile can be placed in the geppetto-showcase folder

Closes #24 