### PR TITLE
3D Scene consuming 100% CPU resources issue fix

### DIFF
--- a/geppetto-showcase/yarn.lock
+++ b/geppetto-showcase/yarn.lock
@@ -1173,11 +1173,11 @@
     react-is "^16.8.0 || ^17.0.0"
 
 "@metacell/geppetto-meta-client@file:.yalc/@metacell/geppetto-meta-client":
-  version "0.0.4"
+  version "0.0.5"
   dependencies:
     "@material-ui/core" "^4.1.3"
-    "@metacell/geppetto-meta-core" "0.0.4"
-    "@metacell/geppetto-meta-ui" "0.0.4"
+    "@metacell/geppetto-meta-core" "0.0.5"
+    "@metacell/geppetto-meta-ui" "0.0.5"
     anchorme "^0.7.1"
     backbone "^1.3.3"
     backbone-associations "^0.6.2"
@@ -1218,8 +1218,8 @@
     underscore "~1.9.1"
     url-join "^4.0.0"
 
-"@metacell/geppetto-meta-core@0.0.4", "@metacell/geppetto-meta-core@file:.yalc/@metacell/geppetto-meta-core":
-  version "0.0.4"
+"@metacell/geppetto-meta-core@0.0.5", "@metacell/geppetto-meta-core@file:.yalc/@metacell/geppetto-meta-core":
+  version "0.0.5"
   dependencies:
     backbone "^1.3.3"
     file-saver "^1.3.3"
@@ -1227,8 +1227,8 @@
     jszip "^3.2.1"
     underscore "~1.9.1"
 
-"@metacell/geppetto-meta-ui@0.0.4", "@metacell/geppetto-meta-ui@file:.yalc/@metacell/geppetto-meta-ui":
-  version "0.0.4"
+"@metacell/geppetto-meta-ui@0.0.5", "@metacell/geppetto-meta-ui@file:.yalc/@metacell/geppetto-meta-ui":
+  version "0.0.5"
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.35"
     "@fortawesome/free-solid-svg-icons" "^5.13.0"

--- a/geppetto.js/geppetto-ui/src/3d-canvas/Canvas.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/Canvas.js
@@ -143,6 +143,7 @@ class Canvas extends Component {
         this.threeDEngine.setWireframe(!this.threeDEngine.getWireframe());
         break;
       }
+      this.threeDEngine.requestFrame();
     }
   }
 

--- a/geppetto.js/geppetto-ui/src/3d-canvas/threeDEngine/CameraManager.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/threeDEngine/CameraManager.js
@@ -293,7 +293,12 @@ export default class CameraManager {
    * @param z
    */
   incrementCameraRotate (x, y, z) {
-    this.engine.controls.incrementRotationEnd(x, y, z);
+    //this.engine.controls.incrementRotationEnd(x, y, z);
+    const cam = this.engine.cameraManager.getCamera();
+    x,y,z = 1;
+    cam.rotation.x += x;
+    cam.rotation.y += y;
+    cam.rotation.z += z;
   }
 
   /**
@@ -309,7 +314,11 @@ export default class CameraManager {
    * @param z
    */
   setCameraPosition (x, y, z) {
-    this.engine.controls.setPosition(x, y, z);
+    //this.engine.controls.setPosition(x, y, z);
+    const cam = this.engine.cameraManager.getCamera();
+    cam.position.x = x ;
+    cam.position.y = y ;
+    cam.position.z = z ;
   }
   /**
    * @param rx

--- a/geppetto.js/geppetto-ui/src/3d-canvas/threeDEngine/ThreeDEngine.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/threeDEngine/ThreeDEngine.js
@@ -37,6 +37,7 @@ export default class ThreeDEngine {
     this.cameraManager = null;
     this.renderer = null;
     this.controls = null;
+    this.orbitControls = null;
     this.mouse = { x: 0, y: 0 };
     this.frameId = null;
     this.meshFactory = new MeshFactory(this.scene, linesThreshold);
@@ -57,6 +58,9 @@ export default class ThreeDEngine {
 
     // Setup Lights
     this.setupLights();
+
+    // Setup Controls
+    this.setupOrbitControls();
 
     // Setup Controls
     this.setupControls();
@@ -144,8 +148,18 @@ export default class ThreeDEngine {
     this.cameraManager.getCamera().add(new THREE.PointLight(0xffffff, 1));
   }
 
-  setupControls () {
-    this.controls = new OrbitControls(this.cameraManager.getCamera(), this.renderer.domElement);
+  setupControls() {
+    this.controls = new THREE.TrackballControls(
+      this.cameraManager.getCamera(),
+      this.renderer.domElement,
+      this.cameraHandler,
+    );
+    this.controls.noZoom = false;
+    this.controls.noPan = false;
+  }
+
+  setupOrbitControls () {
+    this.orbitControls = new OrbitControls(this.cameraManager.getCamera(), this.renderer.domElement);
   }
 
   /**
@@ -527,7 +541,7 @@ export default class ThreeDEngine {
     );
 
     //render on demand by attaching to orbit control
-    this.controls.addEventListener('change', () => {
+    this.orbitControls.addEventListener('change', () => {
       this.requestFrame();
     });     
 


### PR DESCRIPTION

While working with the app noticed that the CPU would consume 100% resources, even if the 3d animation is static, this was 
 caused by main loop recursion between requestAnimationFrame and animate(): Now Instead of the animationFrame constant loop, rendering is fired on demand on the following events:

- window resize event
- orbit control change event
- loading a new graph

The initial approach was to plug rendering to any update evento from TrackballControls, but as this class works the other way round (is ThreeDEngine the one firing update on TrackballControls) and TrackballControls expects a constant animation loop this was not possible, so both TrackballControls and OrbitControls co-exist.

This is not an issue as they attend different problems (the first one is used by the tools panel, the second one by the actual ThreeJS rendering window) but ideally they should be merge into a single controller.

That approach was started but as it was consuming a considerable ammount of time, decided to do the "dual control apprach", fix the urgent issue and leave that optimization for later.

Once this is merged to master a scene control merge component request should be created.

For more reference please see the full issue description at:
https://github.com/MetaCell/open-physiology-viewer/issues/31