### PR TITLE
Refactor capture control actions

### DIFF
--- a/geppetto.js/geppetto-ui/src/3d-canvas/Canvas.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/Canvas.js
@@ -26,9 +26,9 @@ class Canvas extends Component {
     this.defaultCameraControlsHandler = this.defaultCameraControlsHandler.bind(this)
     this.defaultCaptureControlsHandler = this.defaultCaptureControlsHandler.bind(this)
   }
-  
+
   constructorFromProps (props) {
-    if (props.captureOptions !== undefined){
+    if (props.captureOptions !== undefined) {
       this.captureControls = React.createRef();
     }
   }
@@ -63,7 +63,7 @@ class Canvas extends Component {
       selectionStrategy
     );
 
-    if (captureOptions){
+    if (captureOptions) {
       this.recorder = new Recorder(this.getCanvasElement())
     }
     await this.threeDEngine.start(data, cameraOptions, true);
@@ -101,22 +101,26 @@ class Canvas extends Component {
   defaultCaptureControlsHandler (action) {
     const { captureOptions } = this.props
     if (this.recorder) {
-      switch (action) {
+      switch (action.type) {
       case captureControlsActions.START:
         this.recorder.startRecording()
         break
       case captureControlsActions.STOP:
         return this.recorder.stopRecording()
-      case captureControlsActions.DOWNLOAD_VIDEO:
-        return this.recorder.download()
+      case captureControlsActions.DOWNLOAD_VIDEO: {
+        const { filename } = action.data;
+        return this.recorder.download(filename)
+      }
       }
     }
     if (captureOptions && captureOptions.screenshotOptions) {
       const { quality, pixelRatio, resolution, filter } = captureOptions.screenshotOptions
-      switch (action){
-      case captureControlsActions.DOWNLOAD_SCREENSHOT:
-        downloadScreenshot(this.getCanvasElement(), quality, resolution, pixelRatio, filter)
+      switch (action.type) {
+      case captureControlsActions.DOWNLOAD_SCREENSHOT:{
+        const { filename } = action.data;
+        downloadScreenshot(this.getCanvasElement(), quality, resolution, pixelRatio, filter, filename)
         break
+      }
       }
     }
   }
@@ -203,7 +207,7 @@ class Canvas extends Component {
     const { cameraControls } = cameraOptions
     const cameraControlsHandler = cameraControls.cameraControlsHandler ? cameraControls.cameraControlsHandler : this.defaultCameraControlsHandler
     let captureInstance = null
-    if (captureOptions){
+    if (captureOptions) {
       const { captureControls } = captureOptions
       const captureControlsHandler = captureControls && captureControls.captureControlsHandler ? captureControls.captureControlsHandler : this.defaultCaptureControlsHandler
       captureInstance = captureControls && captureControls.instance ? (

--- a/geppetto.js/geppetto-ui/src/3d-canvas/captureManager/Recorder.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/captureManager/Recorder.js
@@ -1,3 +1,5 @@
+import { formatDate } from "./utils";
+
 export class Recorder {
   constructor (canvas) {
     this.stream = canvas.captureStream();
@@ -52,7 +54,7 @@ export class Recorder {
 
   download (filename){
     if (!filename){
-      filename = `${Math.random().toString(36).slice(2)}.webm`
+      filename = `CanvasRecording_${formatDate(new Date())}.webm`
     }
     const blob = new Blob(this.recordedBlobs, this.options);
     const url = window.URL.createObjectURL(blob);
@@ -69,7 +71,7 @@ export class Recorder {
     return blob
   }
 
-  getRecordingBlob(){
+  getRecordingBlob (){
     return new Blob(this.recordedBlobs, this.options);
   }
 

--- a/geppetto.js/geppetto-ui/src/3d-canvas/captureManager/Screenshoter.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/captureManager/Screenshoter.js
@@ -1,6 +1,7 @@
 import * as htmlToImage from "html-to-image";
+import { formatDate } from "./utils";
 
-function getOptions(htmlElement, targetResolution, quality, pixelRatio, filter) {
+function getOptions (htmlElement, targetResolution, quality, pixelRatio, filter) {
   const resolution = getResolutionFixedRatio(htmlElement, targetResolution)
   const options = {
     quality: quality,
@@ -43,14 +44,3 @@ function getResolutionFixedRatio (htmlElement, target) {
   }
 }
 
-function formatDate (d) {
-  return `${d.getFullYear()}${(d.getMonth() + 1)}${d.getDate()}-${pad(d.getHours(), 2)}${pad(d.getMinutes(), 2)}${pad(d.getSeconds(), 2)}`;
-}
-
-function pad (num, size) {
-  let s = num + "";
-  while (s.length < size) {
-    s = "0" + s;
-  }
-  return s;
-}

--- a/geppetto.js/geppetto-ui/src/3d-canvas/captureManager/utils.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/captureManager/utils.js
@@ -1,0 +1,11 @@
+export function formatDate (d) {
+  return `${d.getFullYear()}${(d.getMonth() + 1)}${d.getDate()}-${pad(d.getHours(), 2)}${pad(d.getMinutes(), 2)}${pad(d.getSeconds(), 2)}`;
+}
+
+function pad (num, size) {
+  let s = num + "";
+  while (s.length < size) {
+    s = "0" + s;
+  }
+  return s;
+}

--- a/geppetto.js/geppetto-ui/src/3d-canvas/showcase/examples/SimpleInstancesExample.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/showcase/examples/SimpleInstancesExample.js
@@ -102,12 +102,7 @@ class SimpleInstancesExample extends Component {
 
   handleToggle () {
     loadInstances()
-    this.setState({
-      showModel: true, data: getProxyInstances(), cameraOptions: {
-        ...this.state.cameraOptions,
-        reset: true,
-      } 
-    })
+    this.setState({ showModel: true, data: getProxyInstances(), cameraOptions: { ...this.state.cameraOptions, } })
   }
 
   handleClickOutside (event) {

--- a/geppetto.js/geppetto-ui/src/capture-controls/CaptureControls.js
+++ b/geppetto.js/geppetto-ui/src/capture-controls/CaptureControls.js
@@ -14,6 +14,18 @@ export const captureControlsActions = {
   DOWNLOAD_SCREENSHOT: 'DOWNLOAD_SCREENSHOT',
 };
 
+export const captureControlsActionsStart = (() => ({ type: captureControlsActions.START, }));
+export const captureControlsActionsStop = (() => ({ type: captureControlsActions.STOP, }));
+export const captureControlsActionsDownloadVideo = (filename => ({
+  type: captureControlsActions.DOWNLOAD_VIDEO,
+  data: { filename:filename },
+}));
+export const captureControlsActionsDownloadScreenshot = (filename => ({
+  type: captureControlsActions.DOWNLOAD_SCREENSHOT,
+  data: { filename:filename },
+}));
+
+
 const styles = theme => ({ button: { color: theme.palette.button.main, }, });
 
 class CaptureControls extends Component {
@@ -26,9 +38,9 @@ class CaptureControls extends Component {
   handleClickRecord (){
     const { isRecording } = this.state;
     if (isRecording){
-      this.props.captureControlsHandler(captureControlsActions.STOP)
+      this.props.captureControlsHandler(captureControlsActionsStop())
     } else {
-      this.props.captureControlsHandler(captureControlsActions.START)
+      this.props.captureControlsHandler(captureControlsActionsStart())
     }
     this.setState({ isRecording: !isRecording, hasRecorded: true })
   }
@@ -62,14 +74,14 @@ class CaptureControls extends Component {
         { hasRecorded && !isRecording
         && <IconButtonWithTooltip
           disabled={false}
-          onClick={() => captureControlsHandler(captureControlsActions.DOWNLOAD_VIDEO)}
+          onClick={() => captureControlsHandler(captureControlsActionsDownloadVideo())}
           className={`${classes.button} download squareB`}
           tooltip={"Download"}
           icon={faDownload}/>
         }
         <IconButtonWithTooltip
           disabled={false}
-          onClick={() => captureControlsHandler(captureControlsActions.DOWNLOAD_SCREENSHOT)}
+          onClick={() => captureControlsHandler(captureControlsActionsDownloadScreenshot())}
           className={`${classes.button} screenshot squareB`}
           tooltip={"Screenshot"}
           icon={faCamera}/>


### PR DESCRIPTION
- Changes canvas default capture handler argument to be an action object (type, data) so that we can send application parameters (like the filename for the download video / screenshot)
- Updates default download recording name
- Removes wrong flag from canvas simple instances example 
