### PR TITLE
Allow video conversion 'hack' on canvas recorder

### DIFF
--- a/geppetto.js/geppetto-ui/src/3d-canvas/Canvas.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/Canvas.js
@@ -64,7 +64,7 @@ class Canvas extends Component {
     );
 
     if (captureOptions) {
-      this.recorder = new Recorder(this.getCanvasElement())
+      this.recorder = new Recorder(this.getCanvasElement(), captureOptions.recorderOptions)
     }
     await this.threeDEngine.start(data, cameraOptions, true);
     onMount(this.threeDEngine.scene)
@@ -107,10 +107,11 @@ class Canvas extends Component {
         this.recorder.startRecording()
         break
       case captureControlsActions.STOP:
-        return this.recorder.stopRecording()
+        const { options } = action.data;
+        return this.recorder.stopRecording(options)
       case captureControlsActions.DOWNLOAD_VIDEO: {
-        const { filename } = action.data;
-        return this.recorder.download(filename)
+        const { filename, options } = action.data;
+        return this.recorder.download(filename, options)
       }
       }
     }
@@ -300,6 +301,20 @@ Canvas.propTypes = {
        * Component props
        */
       props: PropTypes.shape({})
+    }),
+    /**
+     * Recorder Options
+     */
+    recorderOptions: PropTypes.shape({
+      /**
+       * Media Recorder options
+       */
+      mediaRecorderOptions: PropTypes.shape({
+        mimeType: PropTypes.string,
+      }),
+      blobOptions: PropTypes.shape({
+        type: PropTypes.string,
+      })
     }),
     /**
      * Screenshot Options

--- a/geppetto.js/geppetto-ui/src/3d-canvas/showcase/examples/SimpleInstancesExample.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/showcase/examples/SimpleInstancesExample.js
@@ -129,6 +129,14 @@ class SimpleInstancesExample extends Component {
         instance: CaptureControls,
         props: {}
       },
+      recorderOptions: {
+        mediaRecorderOptions: {
+          mimeType: 'video/webm',
+        },
+        blobOptions:{
+          type: 'video/webm'
+        }
+      },
       screenshotOptions:{
         resolution:{
           width: 3840,

--- a/geppetto.js/geppetto-ui/src/capture-controls/CaptureControls.js
+++ b/geppetto.js/geppetto-ui/src/capture-controls/CaptureControls.js
@@ -15,10 +15,13 @@ export const captureControlsActions = {
 };
 
 export const captureControlsActionsStart = (() => ({ type: captureControlsActions.START, }));
-export const captureControlsActionsStop = (() => ({ type: captureControlsActions.STOP, }));
-export const captureControlsActionsDownloadVideo = (filename => ({
+export const captureControlsActionsStop = ((options) => ({
+  type: captureControlsActions.STOP,
+  data: { options:options },
+}))
+export const captureControlsActionsDownloadVideo = ((filename, options) => ({
   type: captureControlsActions.DOWNLOAD_VIDEO,
-  data: { filename:filename },
+  data: { filename:filename, options:options },
 }));
 export const captureControlsActionsDownloadScreenshot = (filename => ({
   type: captureControlsActions.DOWNLOAD_SCREENSHOT,


### PR DESCRIPTION
Because we are temporarily keeping two release versions of geppetto. Here's the brother of  https://github.com/MetaCell/geppetto-meta/pull/241 PR.

Allows to define the type of the video on the canvas recorder