### PR TITLE
Fix canvas recorder on static canvas content

### DIFF
--- a/geppetto.js/geppetto-ui/src/3d-canvas/captureManager/Recorder.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/captureManager/Recorder.js
@@ -7,6 +7,8 @@ export class Recorder {
     this.setupMediaRecorder(mediaRecorderOptions)
     this.recordedBlobs = []
     this.blobOptions = blobOptions
+    this.ctx = canvas.getContext('webgl')
+    this.animationLoop = this.animationLoop.bind(this)
   }
 
   handleDataAvailable (event) {
@@ -42,6 +44,8 @@ export class Recorder {
       }
     }
     mediaRecorder.ondataavailable = evt => this.handleDataAvailable(evt);
+    mediaRecorder.onstart = () => this.animationLoop();
+
     this.mediaRecorder = mediaRecorder
     this.options = options
     if(!this.blobOptions){
@@ -86,4 +90,11 @@ export class Recorder {
     return new Blob(this.recordedBlobs, options);
   }
 
+  animationLoop() {
+    // draw nothing, but still draw
+    this.ctx.drawArrays(this.ctx.POINTS, 0, 0)
+    if (this.mediaRecorder.state !== "inactive") {
+      requestAnimationFrame(this.animationLoop);
+    }
+  }
 }


### PR DESCRIPTION
It seems that when using the captureStream of the canvas [nothing gets captured when nothing gets painted on the canvas element](https://developers.google.com/web/updates/2016/10/capture-stream).
I tried to force a new frame into the stream before stopping the recording but that didn't seem to work.

I had to implement the following work around based on this [stack overflow reply](https://stackoverflow.com/questions/66813248/video-capture-of-canvas-element-by-mediastream-recording-api-is-not-working):
>So the only working workaround here is to draw on the canvas continuously while we record it. The good thing is that it doesn't need to be painting anything new: we can trick the browser in thinking something new was painted by drawing a transparent rectangle.

Seems to work on Yale project

https://user-images.githubusercontent.com/19196034/146392801-4d595dce-0be5-4a34-8560-6e5b9bf7a2c7.mp4

