### PR TITLE
#12 remove drawer component highlight color when not active

### DIFF
--- a/geppetto-showcase/src/components/DrawerContent.jsx
+++ b/geppetto-showcase/src/components/DrawerContent.jsx
@@ -74,6 +74,9 @@ class DrawerContent extends Component {
 
   isActivePage(page) {
     const { currentPage } = this.props;
+    if (window.location.href.split('/')[3] === "") {
+      return false;
+    }
     return page === currentPage;
   }
 


### PR DESCRIPTION
Issue: When returning to home page of the geppetto showcase, the last active tab would remain highlighted.
Solution: Check the app's url to see if it is in the home page. If yes, remove active tab styling.