### PR TITLE
Feature/95 showcase canvas

### DIFF
--- a/geppetto-showcase/src/components/DrawerContent.jsx
+++ b/geppetto-showcase/src/components/DrawerContent.jsx
@@ -9,7 +9,7 @@ import { withStyles } from '@material-ui/core/styles';
 import pages from '../pages/index';
 import stringSimilarity from 'string-similarity';
 
-const styles = (theme) => ({
+const styles = theme => ({
   nested: {
     paddingLeft: theme.spacing(4),
     textDecoration: 'none',
@@ -41,7 +41,7 @@ const styles = (theme) => ({
 });
 
 class DrawerContent extends Component {
-  constructor(props) {
+  constructor (props) {
     super(props);
     this.state = {
       dataViewersOpen: true,
@@ -56,23 +56,19 @@ class DrawerContent extends Component {
     );
   }
 
-  dataViewersHandler() {
+  dataViewersHandler () {
     this.setState(() => ({ dataViewersOpen: !this.state.dataViewersOpen }));
   }
 
-  navigationLayoutHandler() {
-    this.setState(() => ({
-      navigationLayoutOpen: !this.state.navigationLayoutOpen,
-    }));
+  navigationLayoutHandler () {
+    this.setState(() => ({ navigationLayoutOpen: !this.state.navigationLayoutOpen, }));
   }
 
-  programmaticInterfacesHandler() {
-    this.setState(() => ({
-      programmaticInterfacesOpen: !this.state.programmaticInterfacesOpen,
-    }));
+  programmaticInterfacesHandler () {
+    this.setState(() => ({ programmaticInterfacesOpen: !this.state.programmaticInterfacesOpen, }));
   }
 
-  isActivePage(page) {
+  isActivePage (page) {
     const { currentPage } = this.props;
     if (window.location.href.split('/')[3] === "") {
       return false;
@@ -80,7 +76,7 @@ class DrawerContent extends Component {
     return page === currentPage;
   }
 
-  filterContent(searchFilter) {
+  filterContent (searchFilter) {
     const {
       dataViewersOpen,
       navigationLayoutOpen,
@@ -105,9 +101,7 @@ class DrawerContent extends Component {
       },
     };
 
-    let componentsNames = pages.map((page) => {
-      return page.name;
-    });
+    let componentsNames = pages.map(page => page.name);
 
     const matches = stringSimilarity.findBestMatch(
       searchFilter,
@@ -118,9 +112,7 @@ class DrawerContent extends Component {
       matches.ratings,
       matches.bestMatch.rating
     );
-    let filteredComponentsNames = filteredContent.map((elem) => {
-      return elem.target.toLowerCase();
-    });
+    let filteredComponentsNames = filteredContent.map(elem => elem.target.toLowerCase());
 
     for (let page of pages) {
       if (filteredComponentsNames.includes(page.name.toLowerCase())) {
@@ -140,19 +132,17 @@ class DrawerContent extends Component {
     return content;
   }
 
-  bestMatches(ratings, bestRating, threshold = 0.2) {
-    return ratings.filter((rating) => {
-      return rating.rating >= bestRating - threshold;
-    });
+  bestMatches (ratings, bestRating, threshold = 0.2) {
+    return ratings.filter(rating => rating.rating >= bestRating - threshold);
   }
 
-  render() {
+  render () {
     const { classes, theme, searchFilter, currentPageHandler } = this.props;
     const content = this.filterContent(searchFilter);
 
     return (
       <nav className={classes.lists} aria-label="mailbox folders">
-        {Object.keys(content).map((key) => {
+        {Object.keys(content).map(key => {
           const open = content[key].open;
           const handler = content[key].handler;
           const children = content[key].children;
@@ -164,7 +154,7 @@ class DrawerContent extends Component {
               </ListItem>
               <Collapse component="li" in={open} timeout="auto" unmountOnExit>
                 <List disablePadding>
-                  {children.map((value) => {
+                  {children.map(value => {
                     const name = value.name;
                     const to = value.to;
                     const disabled = value.disabled;
@@ -172,9 +162,7 @@ class DrawerContent extends Component {
                       <ListItem
                         key={value.name}
                         button
-                        {...(this.isActivePage(to) && {
-                          style: { color: theme.palette.primary.main },
-                        })}
+                        {...(this.isActivePage(to) && { style: { color: theme.palette.primary.main }, })}
                         className={classes.nested}
                         component={Link}
                         to={to}

--- a/geppetto-showcase/src/components/showcase/Showcase.jsx
+++ b/geppetto-showcase/src/components/showcase/Showcase.jsx
@@ -6,6 +6,8 @@ import Paper from '@material-ui/core/Paper';
 import Chip from '@material-ui/core/Chip';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 import PropsTable from './PropsTable';
 import BottomNavigation from '../BottomNavigation';
@@ -52,7 +54,7 @@ const styles = theme => ({
   library: { margin: theme.spacing(1), },
 });
 
-function TabPanel(props) {
+function TabPanel (props) {
   const { children, value, index, ...other } = props;
 
   return (
@@ -78,7 +80,7 @@ TabPanel.propTypes = {
   value: PropTypes.any.isRequired,
 };
 
-function a11yProps(index) {
+function a11yProps (index) {
   return {
     id: `simple-tab-${index}`,
     'aria-controls': `simple-tabpanel-${index}`,
@@ -112,6 +114,27 @@ class Showcase extends Component {
                     <Tab label={obj.name} key={obj.name} {...a11yProps(index)}/>
                   ))}
                 </Tabs>
+                {configs.examples.map((obj, index) => {
+                  const file = obj.file.default.split('\n').join('\n');
+                  return (
+                    <TabPanel value={this.state.tabValue} index={index} key={`tabpanel-${obj.name}`}>
+                      <div key={obj.name}>
+                        <h2 className={classes.secondaryTitle}>{obj.name}</h2>
+                        <span className={classes.secondaryDescription}>
+                          {obj.description}
+                        </span>
+                        <Paper variant="outlined">
+                          <div className={classes.centerComponent}>
+                            <obj.component ref={this.componentRef} />
+                          </div>
+                        </Paper>
+                        <Code file={file} element={configs.reactElement}></Code>
+                      </div>
+                    
+                    </TabPanel>
+                  );
+                })
+                }
               </>
               : <>
                 {configs.examples.map(obj => {

--- a/geppetto-showcase/src/components/showcase/Showcase.jsx
+++ b/geppetto-showcase/src/components/showcase/Showcase.jsx
@@ -109,7 +109,7 @@ class Showcase extends Component {
           {
             typeof createTabsForExamples !== 'undefined' && createTabsForExamples
               ? <>
-                <Tabs value={this.state.tabValue} aria-label="showcase-examples-tabs" variant="fullWidth" onChange={(e, newTabValue) => this.setState(() => ({ tabValue: newTabValue }))}>
+                <Tabs value={this.state.tabValue} indicatorColor="primary" aria-label="showcase-examples-tabs" variant="fullWidth" onChange={(e, newTabValue) => this.setState(() => ({ tabValue: newTabValue }))}>
                   {configs.examples.map((obj, index) => (
                     <Tab label={obj.name} key={obj.name} {...a11yProps(index)}/>
                   ))}

--- a/geppetto-showcase/src/components/showcase/Showcase.jsx
+++ b/geppetto-showcase/src/components/showcase/Showcase.jsx
@@ -4,10 +4,13 @@ import Code from './Code';
 import { getConfigFromMarkdown } from './ShowcaseUtils';
 import Paper from '@material-ui/core/Paper';
 import Chip from '@material-ui/core/Chip';
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+import PropTypes from 'prop-types';
 import PropsTable from './PropsTable';
 import BottomNavigation from '../BottomNavigation';
 
-const styles = (theme) => ({
+const styles = theme => ({
   root: {
     width: '100%',
     paddingBottom: theme.spacing(5),
@@ -46,19 +49,51 @@ const styles = (theme) => ({
     display: 'table',
     margin: '0 auto',
   },
-  library: {
-    margin: theme.spacing(1),
-  },
+  library: { margin: theme.spacing(1), },
 });
 
+function TabPanel(props) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <Box p={3}>
+          <Typography>{children}</Typography>
+        </Box>
+      )}
+    </div>
+  );
+}
+
+TabPanel.propTypes = {
+  children: PropTypes.node,
+  index: PropTypes.any.isRequired,
+  value: PropTypes.any.isRequired,
+};
+
+function a11yProps(index) {
+  return {
+    id: `simple-tab-${index}`,
+    'aria-controls': `simple-tabpanel-${index}`,
+  };
+}
+
 class Showcase extends Component {
-  constructor(props) {
+  constructor (props) {
     super(props);
     this.componentRef = React.createRef();
+    this.state = { tabValue: 0, }
   }
 
-  render() {
-    const { classes, markdown, currentPageHandler } = this.props;
+  render () {
+    const { classes, markdown, currentPageHandler, createTabsForExamples } = this.props;
     const configs = getConfigFromMarkdown(markdown);
 
     return (
@@ -69,23 +104,35 @@ class Showcase extends Component {
           <span className={classes.secondaryDescription}>
             {configs.detailedDescription}
           </span>
-          {configs.examples.map((obj) => {
-            const file = obj.file.default.split('\n').join('\n');
-            return (
-              <div key={obj.name}>
-                <h2 className={classes.secondaryTitle}>{obj.name}</h2>
-                <span className={classes.secondaryDescription}>
-                  {obj.description}
-                </span>
-                <Paper variant="outlined">
-                  <div className={classes.centerComponent}>
-                    <obj.component ref={this.componentRef} />
-                  </div>
-                </Paper>
-                <Code file={file} element={configs.reactElement}></Code>
-              </div>
-            );
-          })}
+          {
+            typeof createTabsForExamples !== 'undefined' && createTabsForExamples
+              ? <>
+                <Tabs value={this.state.tabValue} aria-label="showcase-examples-tabs" variant="fullWidth" onChange={(e, newTabValue) => this.setState(() => ({ tabValue: newTabValue }))}>
+                  {configs.examples.map((obj, index) => (
+                    <Tab label={obj.name} key={obj.name} {...a11yProps(index)}/>
+                  ))}
+                </Tabs>
+              </>
+              : <>
+                {configs.examples.map(obj => {
+                  const file = obj.file.default.split('\n').join('\n');
+                  return (
+                    <div key={obj.name}>
+                      <h2 className={classes.secondaryTitle}>{obj.name}</h2>
+                      <span className={classes.secondaryDescription}>
+                        {obj.description}
+                      </span>
+                      <Paper variant="outlined">
+                        <div className={classes.centerComponent}>
+                          <obj.component ref={this.componentRef} />
+                        </div>
+                      </Paper>
+                      <Code file={file} element={configs.reactElement}></Code>
+                    </div>
+                  );
+                })}
+              </>
+          }
           <h2 className={classes.secondaryTitle}>Props</h2>
           <PropsTable propsConfigs={configs.props} />
           <h2 className={classes.secondaryTitle}>Libraries</h2>

--- a/geppetto-showcase/src/pages/dataviewers/canvas.js
+++ b/geppetto-showcase/src/pages/dataviewers/canvas.js
@@ -11,6 +11,7 @@ export default class ThreeDCanvasPage extends Component {
       <Showcase
         markdown={Canvas3DMarkdown}
         currentPageHandler={currentPageHandler}
+        createTabsForExamples
       />
     );
   }

--- a/geppetto.js/geppetto-ui/src/3d-canvas/showcase/examples/MultipleInstancesExample.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/showcase/examples/MultipleInstancesExample.js
@@ -62,6 +62,7 @@ class MultipleInstancesExample extends Component {
     loadInstances()
     this.state = {
       data: getProxyInstances(),
+      showLoader: false,
       numberOfInstances: 5,
       cameraOptions: {
         angle: 50,
@@ -105,9 +106,10 @@ class MultipleInstancesExample extends Component {
   }
 
   handleToggle () {
+    this.setState({ showLoader: true })
     loadInstances()
     this.setState({
-      showModel: true, data: getProxyInstances(), cameraOptions: {
+      showModel: true, showLoader: false, data: getProxyInstances(), cameraOptions: {
         ...this.state.cameraOptions,
         reset: true,
       } 
@@ -154,32 +156,34 @@ class MultipleInstancesExample extends Component {
 
 
   render () {
-    const { data, cameraOptions, showModel } = this.state
+    const { data, cameraOptions, showModel, showLoader } = this.state
     const canvasData = mapToCanvasData(data)
     const { classes } = this.props
 
-    return showModel ? <div ref={node => this.node = node} className={classes.container}>
-      <>
-        <div>
-          <CanvasTooltip ref={this.tooltipRef} />
-        </div>
-        { 
-          [...Array(this.state.numberOfInstances)].map((e, i) =>
-            <Canvas
-              key={`canvas_${i}`}
-              ref={this.canvasRef}
-              data={canvasData}
-              cameraOptions={cameraOptions}
-              backgroundColor={0x505050}
-              onSelection={this.onSelection}
-              onMount={this.onMount}
-              hoverListeners={[this.hoverHandler]}
-            />
+    return showLoader ? <Loader active={true} /> : showModel ? (
+      <div ref={node => this.node = node} className={classes.container}>
+        <>
+          <div>
+            <CanvasTooltip ref={this.tooltipRef} />
+          </div>
+          { 
+            [...Array(this.state.numberOfInstances)].map((e, i) =>
+              <Canvas
+                key={`canvas_${i}`}
+                ref={this.canvasRef}
+                data={canvasData}
+                cameraOptions={cameraOptions}
+                backgroundColor={0x505050}
+                onSelection={this.onSelection}
+                onMount={this.onMount}
+                hoverListeners={[this.hoverHandler]}
+              />
 
-          )
-        }
-      </>
-    </div> : <Button
+            )
+          }
+        </>
+      </div>
+      ) : <Button
       variant="outlined"
       color="primary"
       onClick={this.handleToggle}

--- a/geppetto.js/geppetto-ui/src/3d-canvas/showcase/examples/SimpleInstancesExample.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/showcase/examples/SimpleInstancesExample.js
@@ -63,6 +63,7 @@ class SimpleInstancesExample extends Component {
     loadInstances()
     this.state = {
       data: getProxyInstances(),
+      showLoader: false,
       cameraOptions: {
         angle: 50,
         near: 0.01,
@@ -105,8 +106,9 @@ class SimpleInstancesExample extends Component {
   }
 
   handleToggle () {
+    this.setState({ showLoader: true })
     loadInstances()
-    this.setState({ showModel: true, data: getProxyInstances(), cameraOptions: { ...this.state.cameraOptions, } })
+    this.setState({ showModel: true, showLoader: false, data: getProxyInstances(), cameraOptions: { ...this.state.cameraOptions, } })
   }
 
   handleClickOutside (event) {
@@ -126,7 +128,7 @@ class SimpleInstancesExample extends Component {
   }
 
   render () {
-    const { data, cameraOptions, showModel } = this.state
+    const { data, cameraOptions, showModel, showLoader } = this.state
     const canvasData = mapToCanvasData(data)
     const { classes } = this.props
 
@@ -154,23 +156,25 @@ class SimpleInstancesExample extends Component {
       },
     }
 
-    return showModel ? <div ref={node => this.node = node} className={classes.container}>
-      <>
-        <div>
-          <CanvasTooltip ref={this.tooltipRef} />
-        </div>
-        <Canvas
-          ref={this.canvasRef}
-          data={canvasData}
-          cameraOptions={cameraOptions}
-          captureOptions={captureOptions}
-          backgroundColor={0x505050}
-          onSelection={this.onSelection}
-          onMount={this.onMount}
-          hoverListeners={[this.hoverHandler]}
-        />
-      </>
-    </div> : <Button
+    return showLoader ? <Loader active={true} /> : showModel ? (
+      <div ref={node => this.node = node} className={classes.container}>
+        <>
+          <div>
+            <CanvasTooltip ref={this.tooltipRef} />
+          </div>
+          <Canvas
+            ref={this.canvasRef}
+            data={canvasData}
+            cameraOptions={cameraOptions}
+            captureOptions={captureOptions}
+            backgroundColor={0x505050}
+            onSelection={this.onSelection}
+            onMount={this.onMount}
+            hoverListeners={[this.hoverHandler]}
+          />
+        </>
+      </div>
+    ) : <Button
       variant="outlined"
       color="primary"
       onClick={this.handleToggle}


### PR DESCRIPTION
- Put showcase canvas page examples into tabs for user-friendly experience.
- Add loader to simple and multiple instance examples in canvas showcase.
- Small eslint fixes

Current look of canvas page in geppetto showcase:
![image](https://user-images.githubusercontent.com/40673427/153322349-f616bcb4-c189-419e-811c-bbb1471fd70c.png)
