### PR TITLE
#459 fix: Update default draco decoder path

### DIFF
--- a/geppetto-showcase/src/examples/3d-canvas/SimpleInstancesExample.js
+++ b/geppetto-showcase/src/examples/3d-canvas/SimpleInstancesExample.js
@@ -157,6 +157,7 @@ class SimpleInstancesExample extends Component {
             onSelection={this.onSelection}
             onMount={this.onMount}
             onHoverListeners={{ 'hoverId':this.hoverHandler }}
+            dracoDecoderPath={'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/jsm/libs/draco/'}
           />
         </>
       </div>

--- a/geppetto.js/geppetto-ui/src/3d-canvas/Canvas.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/Canvas.js
@@ -431,7 +431,7 @@ Canvas.defaultProps = {
   onMount: () => {},
   onUpdateStart: () => {},
   onUpdateEnd: () => {},
-  dracoDecoderPath: '../../../node_modules/three/examples/js/libs/draco/'
+  dracoDecoderPath: 'https://www.gstatic.com/draco/versioned/decoders/1.5.5/'
 };
 
 Canvas.propTypes = {

--- a/geppetto.js/geppetto-ui/src/3d-canvas/Canvas.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/Canvas.js
@@ -55,6 +55,7 @@ class Canvas extends Component {
       onMount,
       onUpdateStart,
       onUpdateEnd,
+      dracoDecoderPath
     } = this.props;
     const hasCaptureOptions = captureOptions !== undefined
 
@@ -70,7 +71,8 @@ class Canvas extends Component {
       selectionStrategy,
       onHoverListeners,
       onEmptyHoverListener,
-      hasCaptureOptions
+      hasCaptureOptions,
+      dracoDecoderPath
     );
     onUpdateStart();
     await this.threeDEngine.updateInstances(data);
@@ -429,6 +431,7 @@ Canvas.defaultProps = {
   onMount: () => {},
   onUpdateStart: () => {},
   onUpdateEnd: () => {},
+  dracoDecoderPath: '../../../node_modules/three/examples/js/libs/draco/'
 };
 
 Canvas.propTypes = {
@@ -664,6 +667,10 @@ Canvas.propTypes = {
    * Function to callback when the loading of elements of the canvas ends
    */
   onUpdateEnd: PropTypes.func,
+  /**
+   * Path to the draco decoder
+   */
+  dracoDecoderPath: PropTypes.string
 };
 
 export default withStyles(styles)(Canvas);

--- a/geppetto.js/geppetto-ui/src/3d-canvas/threeDEngine/MeshFactory.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/threeDEngine/MeshFactory.js
@@ -1,5 +1,5 @@
 import particle from '../textures/particle.png';
-import { hasVisualType, hasVisualValue } from "./util";
+import { hasVisualValue } from "./util";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader";
 import { OBJLoader } from "./OBJLoader";
 import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader";
@@ -38,7 +38,7 @@ export default class MeshFactory {
 
   setupLoaders (){
     const dracoLoader = new DRACOLoader()
-    dracoLoader.setDecoderPath('https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/jsm/libs/draco/');
+    dracoLoader.setDecoderPath('../../../node_modules/three/examples/js/libs/draco/');
 
     const manager = new this.THREE.LoadingManager();
     manager.onProgress = function (item, loaded, total) {

--- a/geppetto.js/geppetto-ui/src/3d-canvas/threeDEngine/MeshFactory.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/threeDEngine/MeshFactory.js
@@ -16,6 +16,7 @@ export default class MeshFactory {
     linePrecisionMinRadius = 300,
     minAllowedLinePrecision = 1,
     particleTexture,
+    dracoDecoderPath,
     THREE
   ) {
     this.scene = scene;
@@ -30,6 +31,7 @@ export default class MeshFactory {
     this.minAllowedLinePrecision = minAllowedLinePrecision;
     this.linesThreshold = linesThreshold;
     this.particleTexture = particleTexture;
+    this.dracoDecoderPath = dracoDecoderPath ? dracoDecoderPath : '../../../node_modules/three/examples/js/libs/draco/'
     this.THREE = THREE ? THREE : require('three');
     this.THREE.Cache.enabled = true;
     this.setupLoaders();
@@ -38,7 +40,7 @@ export default class MeshFactory {
 
   setupLoaders (){
     const dracoLoader = new DRACOLoader()
-    dracoLoader.setDecoderPath('../../../node_modules/three/examples/js/libs/draco/');
+    dracoLoader.setDecoderPath(this.dracoDecoderPath);
 
     const manager = new this.THREE.LoadingManager();
     manager.onProgress = function (item, loaded, total) {

--- a/geppetto.js/geppetto-ui/src/3d-canvas/threeDEngine/MeshFactory.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/threeDEngine/MeshFactory.js
@@ -31,7 +31,7 @@ export default class MeshFactory {
     this.minAllowedLinePrecision = minAllowedLinePrecision;
     this.linesThreshold = linesThreshold;
     this.particleTexture = particleTexture;
-    this.dracoDecoderPath = dracoDecoderPath ? dracoDecoderPath : '../../../node_modules/three/examples/js/libs/draco/'
+    this.dracoDecoderPath = dracoDecoderPath ? dracoDecoderPath : 'https://www.gstatic.com/draco/versioned/decoders/1.5.5/'
     this.THREE = THREE ? THREE : require('three');
     this.THREE.Cache.enabled = true;
     this.setupLoaders();

--- a/geppetto.js/geppetto-ui/src/3d-canvas/threeDEngine/ThreeDEngine.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/threeDEngine/ThreeDEngine.js
@@ -33,7 +33,8 @@ export default class ThreeDEngine {
     selectionStrategy,
     onHoverListeners,
     onEmptyHoverListener,
-    preserveDrawingBuffer
+    preserveDrawingBuffer,
+    dracoDecoderPath
   ) {
     this.scene = new THREE.Scene();
     this.scene.background = new THREE.Color(backgroundColor);
@@ -45,7 +46,8 @@ export default class ThreeDEngine {
     this.mouse = { x: 0, y: 0 };
     this.mouseContainer = { x: 0, y: 0 }
     this.frameId = null;
-    this.meshFactory = new MeshFactory(this.scene, linesThreshold, cameraOptions.depthWrite);
+    this.meshFactory = new MeshFactory(this.scene, linesThreshold, cameraOptions.depthWrite, 300, 1,
+        null, dracoDecoderPath, null);
     this.pickingEnabled = pickingEnabled;
     this.onHoverListeners = onHoverListeners;
     this.onEmptyHoverListener = onEmptyHoverListener ;


### PR DESCRIPTION
closes #459 

- Add prop to define draco decoder path
- Changes default draco decoder path to cdn [recommended by draco](https://github.com/google/draco)