### PR TITLE
feature/476 fix: undefined selectedTab

### DIFF
--- a/geppetto.js/geppetto-ui/src/flex-layout/src/model/TabSetNode.ts
+++ b/geppetto.js/geppetto-ui/src/flex-layout/src/model/TabSetNode.ts
@@ -398,11 +398,15 @@ class TabSetNode extends Node implements IDraggable, IDropTarget {
                 }
                 // console.log("added child at : " + insertPos);
             } else {
-                dragNode.getChildren().forEach((child, i) => {
+                for (let i = 0; i < dragNode.getChildren().length; i++) {
+                    const child = dragNode.getChildren()[i];
                     this._addChild(child, insertPos);
                     // console.log("added child at : " + insertPos);
                     insertPos++;
-                });
+                }
+                if (this.getSelected() === -1 && this._children.length > 0) {
+                    this._setSelected(0);
+                }
             }
             this._model._setActiveTabset(this);
         } else {


### PR DESCRIPTION
fix for Error "undefined selectedTab should not happen" using enableDeleteWhenEmpty false as seen in [#340](https://github.com/caplin/FlexLayout/issues/340)