### PR TITLE
#481 fix: Backport retina displays fix

### DIFF
--- a/geppetto.js/geppetto-ui/src/3d-canvas/threeDEngine/ThreeDEngine.js
+++ b/geppetto.js/geppetto-ui/src/3d-canvas/threeDEngine/ThreeDEngine.js
@@ -74,9 +74,9 @@ export default class ThreeDEngine {
     this.setupListeners(onSelection);
 
     this.start = this.start.bind(this);
+    this.stop = this.stop.bind(this);
     this.animate = this.animate.bind(this);
     this.renderScene = this.renderScene.bind(this);
-    this.stop = this.stop.bind(this);
     this.resize = this.resize.bind(this);
   }
 
@@ -730,14 +730,14 @@ export default class ThreeDEngine {
           that.mouse.y
             = -(
               (event.clientY
-                - that.renderer.domElement.getBoundingClientRect().top)
+                - that.renderer.domElement.getBoundingClientRect().top) * window.devicePixelRatio
               / that.renderer.domElement.getBoundingClientRect().height
             )
               * 2
             + 1;
           that.mouse.x
             = ((event.clientX
-              - that.renderer.domElement.getBoundingClientRect().left)
+              - that.renderer.domElement.getBoundingClientRect().left) * window.devicePixelRatio
               / that.renderer.domElement.getBoundingClientRect().width)
               * 2
             - 1;
@@ -821,14 +821,14 @@ export default class ThreeDEngine {
         that.mouse.y
           = -(
             (event.clientY
-              - that.renderer.domElement.getBoundingClientRect().top)
+              - that.renderer.domElement.getBoundingClientRect().top) * window.devicePixelRatio
             / that.renderer.domElement.height
           )
             * 2
           + 1;
         that.mouse.x
           = ((event.clientX
-            - that.renderer.domElement.getBoundingClientRect().left)
+            - that.renderer.domElement.getBoundingClientRect().left) * window.devicePixelRatio
             / that.renderer.domElement.width)
             * 2
           - 1;


### PR DESCRIPTION
closes #481 

@enicolasgomez Would you please create a new release with the present fix?
This was done on top of release/0.0.7.1 (or tag/0.8.1)

before:

https://user-images.githubusercontent.com/19196034/216037769-14b44e52-b6ea-4a7d-838d-40f7f628fbb2.mp4

after:

https://user-images.githubusercontent.com/19196034/216037792-fda1c009-c7d6-42cb-85c0-d6cff1677bf2.mp4

