### PR TITLE
GEP-121 ListViewer is still not working

### DIFF
--- a/geppetto.js/geppetto-ui/src/list-viewer/utils/Griddle.js
+++ b/geppetto.js/geppetto-ui/src/list-viewer/utils/Griddle.js
@@ -6,6 +6,7 @@ import {
 } from 'redux';
 
 import Griddle, { plugins } from 'griddle-react';
+import init from 'griddle-react/dist/module/utils/initializer';
 
 const { CorePlugin: corePlugin } = plugins
 


### PR DESCRIPTION
Issue #GEP-121
Problem: ListViewer is still not working
Solution: Just added line of code where init function is imported
import init from 'griddle-react/dist/module/utils/initializer';
here is the link to the screenshot video
[screen-capture.webm](https://github.com/MetaCell/geppetto-meta/assets/67194168/ab2f72b6-72ea-43f5-b034-f56cf36cce7a)



