### PR TITLE
Feature/menu example

### DIFF
--- a/geppetto-showcase/src/App.js
+++ b/geppetto-showcase/src/App.js
@@ -25,6 +25,20 @@ export default class App extends Component {
         button: { main: '#fc6320' },
         toolbarBackground: { main: 'rgb(0,0,0,0.5)' },
       },
+      overrides: {
+        MuiListItemIcon: {
+          root: {
+            '& i.my-svg-icon': {
+              backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20' fill='none'%3E%3Cpath d='M7.32911 13.2291L3.85411 9.75414L2.67078 10.9291L7.32911 15.5875L17.3291 5.58748L16.1541 4.41248L7.32911 13.2291Z' fill='%23D6D5D7'/%3E%3C/svg%3E");`,
+              display: 'inline-block',
+              width: '16px',
+              height: '12px',
+              backgroundSize: 'contain',
+              backgroundRepeat: 'no-repeat'
+            }
+          }
+        }
+      }
     });
     theme = responsiveFontSizes(theme);
 

--- a/geppetto-showcase/src/examples/menu/menuConfiguration.js
+++ b/geppetto-showcase/src/examples/menu/menuConfiguration.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 const toolbarMenu = {
   global: {
     buttonsStyle: {
@@ -122,7 +124,14 @@ const toolbarMenu = {
           },
         },
         {
-          label: 'Feedback',
+          label: (
+              <>
+                Feedback
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+                  <path d="M7.32911 13.2291L3.85411 9.75414L2.67078 10.9291L7.32911 15.5875L17.3291 5.58748L16.1541 4.41248L7.32911 13.2291Z" fill="#5A48E6"/>
+                </svg>
+              </>
+          ),
           icon: '',
           action: {
             handlerAction: 'clickFeedback',

--- a/geppetto-showcase/src/examples/menu/menuConfiguration.js
+++ b/geppetto-showcase/src/examples/menu/menuConfiguration.js
@@ -126,6 +126,9 @@ const toolbarMenu = {
         {
           label: (
               <>
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+                  <path d="M7.32911 13.2291L3.85411 9.75414L2.67078 10.9291L7.32911 15.5875L17.3291 5.58748L16.1541 4.41248L7.32911 13.2291Z" fill="#D6D5D7"/>
+                </svg>
                 Feedback
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
                   <path d="M7.32911 13.2291L3.85411 9.75414L2.67078 10.9291L7.32911 15.5875L17.3291 5.58748L16.1541 4.41248L7.32911 13.2291Z" fill="#5A48E6"/>

--- a/geppetto-showcase/src/examples/menu/menuConfiguration.js
+++ b/geppetto-showcase/src/examples/menu/menuConfiguration.js
@@ -131,7 +131,7 @@ const toolbarMenu = {
         },
         {
           label: 'Social media',
-          icon: '',
+          icon: 'my-svg-icon',
           position: 'right-start',
           action: {
             handlerAction: 'submenu',


### PR DESCRIPTION
Replies to questions raised [here](https://github.com/MetaCell/cfos-visualizer/pull/2):

- Adds (workaround) example of how to add custom icons to the menu

![image](https://github.com/MetaCell/geppetto-meta/assets/19196034/ff5296e0-41fc-46ca-8b22-0391392bab12)
