### PR TITLE
Update PyEcore version for pygeppetto

### DIFF
--- a/pygeppetto/requirements.txt
+++ b/pygeppetto/requirements.txt
@@ -1,5 +1,5 @@
 airspeed==0.6.0
 Deprecated==1.2.14
 multimethod==1.11.2
-pyecore==0.15.1
+pyecore==0.15.2
 requests==2.31.0

--- a/pygeppetto/setup.py
+++ b/pygeppetto/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 required_packages = [
     'pyecore>=0.11.5',


### PR DESCRIPTION
Upgrade from pyecore 0.15.1 to 0.15.2. This version brings a patch for the JSON serialization of primitive values for a bug that was introduced in pyecore 0.15.1.