### PR TITLE
Feature/gep 173

### DIFF
--- a/examples/layout-manager-playground/src/redux/store.ts
+++ b/examples/layout-manager-playground/src/redux/store.ts
@@ -7,13 +7,14 @@ function configureStore() {
   const reducers = {};
   const INIT_STATE = {};
   const isMinimizeEnabled = true;
-  return createStore(
+  const {layoutManager, store} = createStore(
     reducers,
     INIT_STATE,
     middlewares,
     // @ts-expect-error The two objects misses some fields to be type-coherent with the signature, but those fields are not really required
     { baseLayout, componentMap, isMinimizeEnabled },
   );
+  return store;
 }
 
 const store = configureStore()

--- a/examples/layout-manager-playground/src/redux/store.ts
+++ b/examples/layout-manager-playground/src/redux/store.ts
@@ -1,4 +1,4 @@
-import { createStore } from '@metacell/geppetto-meta-client/common';
+import { createLayoutAndStore } from '@metacell/geppetto-meta-client/common';
 import baseLayout from '../layout/defaultLayout';
 import componentMap from '../layout/componentsMap';
 
@@ -7,7 +7,7 @@ function configureStore() {
   const reducers = {};
   const INIT_STATE = {};
   const isMinimizeEnabled = true;
-  const {layoutManager, store} = createStore(
+  const { store } = createLayoutAndStore(
     reducers,
     INIT_STATE,
     middlewares,

--- a/examples/multiple-layout-manager-playground/src/layout-manager/layoutManagerFactory.ts
+++ b/examples/multiple-layout-manager-playground/src/layout-manager/layoutManagerFactory.ts
@@ -1,5 +1,5 @@
 
-import { createStore } from '@metacell/geppetto-meta-client/common';
+import { createLayoutAndStore } from '@metacell/geppetto-meta-client/common';
 
 import baseLayout from '../layout/defaultLayout'
 import componentMap from "../layout/componentsMap.tsx";
@@ -12,7 +12,7 @@ function getLayoutManagerAndStore() {
   const reducers = {};
   const INIT_STATE = {};
   const isMinimizeEnabled = true;
-  return createStore(
+  return createLayoutAndStore(
     reducers,
     INIT_STATE,
     middlewares,

--- a/examples/multiple-layout-manager-playground/src/layout-manager/layoutManagerFactory.ts
+++ b/examples/multiple-layout-manager-playground/src/layout-manager/layoutManagerFactory.ts
@@ -1,69 +1,23 @@
-import { initLayoutManager } from "@metacell/geppetto-meta-client/common/layout/LayoutManager";
-import type { WidgetMap } from "@metacell/geppetto-meta-client/common/layout/model";
-import { callbacksMiddleware } from "@metacell/geppetto-meta-client/common/middleware/geppettoMiddleware";
-import geppettoClientReducer, { clientInitialState, type ClientState } from "@metacell/geppetto-meta-client/common/reducer/geppettoClient";
-import { type LayoutState, layout, layoutInitialState, widgets } from "@metacell/geppetto-meta-client/common/reducer/geppettoLayout";
-import { reducerDecorator } from "@metacell/geppetto-meta-client/common/reducer/reducerDecorator";
-import { type Action, type Reducer, combineReducers, configureStore } from "@reduxjs/toolkit";
-import { SET_WORKSPACE_ID } from "./actionsTypes.ts";
 
+import { createStore } from '@metacell/geppetto-meta-client/common';
 
 import baseLayout from '../layout/defaultLayout'
 import componentMap from "../layout/componentsMap.tsx";
 
-export interface RootState {
-    client: ClientState;
-    layout: LayoutState;
-    widgets: WidgetMap;
-    workspaceId: string;
+
+
+
+function getLayoutManagerAndStore() {
+  const middlewares: never[] = [];
+  const reducers = {};
+  const INIT_STATE = {};
+  const isMinimizeEnabled = true;
+  return createStore(
+    reducers,
+    INIT_STATE,
+    middlewares,
+    { baseLayout, componentMap, isMinimizeEnabled },
+  );
 }
-
-const workspaceReducer = (state = "", action) => {
-  switch (action.type) {
-    case SET_WORKSPACE_ID:
-      return action.payload;
-    default:
-      return state;
-  }
-};
-
-const initialState = {
-  client: clientInitialState,
-  layout: layoutInitialState,
-  widgets: {},
-  workspaceId: "",
-};
-
-const rootReducer: Reducer<RootState> = reducerDecorator(
-  combineReducers<RootState>({
-    client: geppettoClientReducer,
-    layout,
-    widgets,
-    workspaceId: workspaceReducer,
-  }),
-);
-
-const getLayoutManagerAndStore = (workspaceId: string) => {
-  const layoutManager = initLayoutManager(baseLayout, componentMap, undefined, false);
-  const middlewareEnhancer = (getDefaultMiddleware) => getDefaultMiddleware().concat(callbacksMiddleware, layoutManager.middleware);
-
-  const storeOptions: {
-        preloadedState: Partial<RootState>;
-        reducer: (state: RootState | undefined, action: Action) => RootState;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        middleware: (getDefaultMiddleware: ReturnType<ReturnType<any>>) => any;
-    } = {
-      reducer: rootReducer,
-      middleware: middlewareEnhancer,
-      preloadedState: { ...initialState, workspaceId: workspaceId } as Partial<RootState>,
-    };
-
-  const store = configureStore(storeOptions);
-
-  return {
-    layoutManager,
-    store,
-  };
-};
 
 export default getLayoutManagerAndStore;

--- a/examples/redux-react-app/src/redux/store.js
+++ b/examples/redux-react-app/src/redux/store.js
@@ -19,7 +19,7 @@ const reducers = {
  *
  * You can build upon geppetto-meta's configuration by passing your own reducers, initial state and middlewares.
  */
-const store = createStore(
+const {layoutManager ,store} = createStore(
   reducers,
   INIT_STATE,
   [exampleMiddleware],

--- a/examples/redux-react-app/src/redux/store.js
+++ b/examples/redux-react-app/src/redux/store.js
@@ -1,7 +1,7 @@
 import componentMap from '../app/componentMap';
 import { exampleMiddleware } from './middleware'
 import { layout as baseLayout } from '../app/layout';
-import { createStore } from '@metacell/geppetto-meta-client/common';
+import { createLayoutAndStore } from '@metacell/geppetto-meta-client/common';
 import exampleReducer from './reducer';
 
 const INIT_STATE = {
@@ -15,11 +15,11 @@ const reducers = {
 };
 
 /**
- * The createStore function is used to initialize the redux store & configure the layout.
+ * The createLayoutAndStore function is used to initialize the redux store & configure the layout.
  *
  * You can build upon geppetto-meta's configuration by passing your own reducers, initial state and middlewares.
  */
-const {layoutManager ,store} = createStore(
+const { store } = createLayoutAndStore(
   reducers,
   INIT_STATE,
   [exampleMiddleware],

--- a/geppetto.js/geppetto-client/src/common/EventManager.ts
+++ b/geppetto.js/geppetto-client/src/common/EventManager.ts
@@ -76,7 +76,7 @@ class EventManager {
 
   setStore(store: Store<any, GeppettoAction>) {
     if (this.initialized) {
-      throw Error("Cannot set the store more than once")
+      console.warn("Multiple stores found, EventManager will use the last one set.")
     }
     this.store = store;
     this.initialized = true;

--- a/geppetto.js/geppetto-client/src/common/index.ts
+++ b/geppetto.js/geppetto-client/src/common/index.ts
@@ -1,2 +1,2 @@
-export { createStore } from './store';
+export { createStore, createLayoutAndStore } from './store';
 export * from './layout';

--- a/geppetto.js/geppetto-client/src/common/store.ts
+++ b/geppetto.js/geppetto-client/src/common/store.ts
@@ -34,6 +34,43 @@ const staticReducers = {
 //const storeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({trace: true, traceLimit: 25}) || redux.compose;
 const storeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || redux.compose;
 
+function getLayoutAndStore(
+  reducers: redux.ReducersMapObject,
+  state: any,
+  enhancers: redux.Middleware[],
+  layout: {
+    iconFactory?: TabsetIconFactory;
+    baseLayout?: LayoutState;
+    componentMap: ComponentMap;
+    isMinimizeEnabled?: boolean;
+  } = { componentMap: {} }
+) {
+  // Initialize the layout manager
+  const layoutManager = initLayoutManager(
+    layout.baseLayout || layoutInitialState,
+    layout.componentMap,
+    layout.iconFactory,
+    layout.isMinimizeEnabled || false
+  );
+
+  // Combine all middleware
+  const allMiddlewares = [...enhancers, callbacksMiddleware, layoutManager.middleware];
+
+  // Create the store
+  const store = redux.createStore(
+    reducerDecorator(redux.combineReducers({ ...staticReducers, ...reducers })),
+    { ...initialState, ...state },
+    storeEnhancers(redux.applyMiddleware(...allMiddlewares))
+  );
+
+  EventManager.setStore(store);
+
+  return { layoutManager, store };
+}
+
+/**
+ * @deprecated Use createLayoutAndStore instead.
+ */
 export function createStore(
   reducers: redux.ReducersMapObject,
   state: any,
@@ -44,30 +81,23 @@ export function createStore(
     componentMap: ComponentMap;
     isMinimizeEnabled?: boolean;
   } = { componentMap: {} }
-): { layoutManager: LayoutManager; store: redux.Store<any, GeppettoAction> } {
-  // Initialize layout manager with provided layout settings
-  const layoutManager = initLayoutManager(
-    layout.baseLayout || layoutInitialState,
-    layout.componentMap,
-    layout.iconFactory,
-    layout.isMinimizeEnabled || false
-  );
-
-  // Compose all middleware including layout manager middleware
-  const allMiddlewares = [...enhancers, callbacksMiddleware, layoutManager.middleware];
-
-  // Create a Redux store with composed middleware
-  const store = redux.createStore(
-    reducerDecorator(redux.combineReducers({ ...staticReducers, ...reducers })),
-    { ...initialState, ...state },
-    storeEnhancers(redux.applyMiddleware(...allMiddlewares))
-  );
-
-  // Set the store in the EventManager for global access
-  EventManager.setStore(store);
-
-  return { layoutManager, store };
+): redux.Store<any, GeppettoAction> {
+  const { store } = getLayoutAndStore(reducers, state, enhancers, layout);
+  return store;
 }
 
+export function createLayoutAndStore(
+  reducers: redux.ReducersMapObject,
+  state: any,
+  enhancers: redux.Middleware[],
+  layout: {
+    iconFactory?: TabsetIconFactory;
+    baseLayout?: LayoutState;
+    componentMap: ComponentMap;
+    isMinimizeEnabled?: boolean;
+  } = { componentMap: {} }
+): { layoutManager: LayoutManager; store: redux.Store<any, GeppettoAction> } {
+  return getLayoutAndStore(reducers, state, enhancers, layout);
+}
 
 export default createStore;

--- a/geppetto.js/geppetto-client/src/common/store.ts
+++ b/geppetto.js/geppetto-client/src/common/store.ts
@@ -1,7 +1,7 @@
 import * as redux from "redux";
 import { callbacksMiddleware } from './middleware/geppettoMiddleware';
 
-import { initLayoutManager } from './layout/LayoutManager';
+import { initLayoutManager, LayoutManager } from './layout/LayoutManager';
 import EventManager from './EventManager';
 import { layoutInitialState, type LayoutState, layout, widgets } from './reducer/geppettoLayout';
 import geppettoClientReducer, { clientInitialState, type ClientState } from './reducer/geppettoClient';
@@ -34,24 +34,40 @@ const staticReducers = {
 //const storeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({trace: true, traceLimit: 25}) || redux.compose;
 const storeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || redux.compose;
 
-
-export function createStore (
+export function createStore(
   reducers: redux.ReducersMapObject,
   state: any,
   enhancers: redux.Middleware[],
-  layout: {iconFactory?: TabsetIconFactory, baseLayout?: LayoutState, componentMap: ComponentMap, isMinimizeEnabled?: boolean}={componentMap: {}}): redux.Store<any, GeppettoAction> {
+  layout: {
+    iconFactory?: TabsetIconFactory;
+    baseLayout?: LayoutState;
+    componentMap: ComponentMap;
+    isMinimizeEnabled?: boolean;
+  } = { componentMap: {} }
+): { layoutManager: LayoutManager; store: redux.Store<any, GeppettoAction> } {
+  // Initialize layout manager with provided layout settings
+  const layoutManager = initLayoutManager(
+    layout.baseLayout || layoutInitialState,
+    layout.componentMap,
+    layout.iconFactory,
+    layout.isMinimizeEnabled || false
+  );
 
-  const layoutManager = initLayoutManager(layout.baseLayout || layoutInitialState, layout.componentMap, layout.iconFactory, layout.isMinimizeEnabled || false);
+  // Compose all middleware including layout manager middleware
   const allMiddlewares = [...enhancers, callbacksMiddleware, layoutManager.middleware];
 
+  // Create a Redux store with composed middleware
   const store = redux.createStore(
-    reducerDecorator(redux.combineReducers({...staticReducers, ...reducers})),
-    {...initialState, ...state },
+    reducerDecorator(redux.combineReducers({ ...staticReducers, ...reducers })),
+    { ...initialState, ...state },
     storeEnhancers(redux.applyMiddleware(...allMiddlewares))
   );
+
+  // Set the store in the EventManager for global access
   EventManager.setStore(store);
 
-  return store;
+  return { layoutManager, store };
 }
+
 
 export default createStore;


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/GEP-173

- Updates createStore function to return the layout manager (breaking change)
- Replaces EventManager error with a warning (but we actually should deprecate EventManager because it's not used and we don't recommend using it)
- Updates examples (I couldn't test the react-redux example change because I don't seem to be able to lunch the application but the other examples were tested locally)